### PR TITLE
Using the symfony discovery to find the translation files

### DIFF
--- a/src/DependencyInjection/EnumTranslationCompilerPass.php
+++ b/src/DependencyInjection/EnumTranslationCompilerPass.php
@@ -11,21 +11,14 @@ use Symfony\Component\Yaml\Yaml;
 class EnumTranslationCompilerPass implements CompilerPassInterface
 {
     /**
-     * @see \Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface::process()
+     * {@inheritdoc}
      */
     public function process(ContainerBuilder $container)
     {
-        foreach ($container->getParameter('kernel.bundles') as $name => $class) {
-            // Special case when using the EntityBundle
-            $base_dir = ($class === 'Hostnet\Bundle\EntityBundle\HostnetEntityBundle')
-                ? $container->getParameter(sprintf('hostnet.entity.%s.path', $container->underscore($name)))
-                : dirname((new \ReflectionClass($class))->getFilename());
-
-            if (!is_dir($dir = $base_dir . '/Resources/translations')) {
-                continue;
-            }
-
-            $this->registerEnums($container, glob($dir . "/enum.*.*"));
+        foreach ($container->getDefinition('translator.default')->getArgument(3)['resource_files'] as $files) {
+            $this->registerEnums($container, array_filter($files, function ($file) {
+                return preg_match('~/enum\.[a-z]+\.[a-z]+$~', $file) === 1;
+            }));
         }
     }
 

--- a/src/HostnetEntityTranslationBundle.php
+++ b/src/HostnetEntityTranslationBundle.php
@@ -13,7 +13,7 @@ use Symfony\Component\HttpKernel\Bundle\Bundle;
 class HostnetEntityTranslationBundle extends Bundle
 {
     /**
-     * @see \Symfony\Component\HttpKernel\Bundle\Bundle::build()
+     * {@inheritdoc}
      */
     public function build(ContainerBuilder $container)
     {

--- a/src/Loader/EnumLoader.php
+++ b/src/Loader/EnumLoader.php
@@ -24,7 +24,7 @@ class EnumLoader implements LoaderInterface
     }
 
     /**
-     * @see \Symfony\Component\Translation\Loader\LoaderInterface::load()
+     * {@inheritdoc}
      */
     public function load($resource, $locale, $domain = 'messages')
     {

--- a/test/DependencyInjection/EnumTranslationCompilerPassTest.php
+++ b/test/DependencyInjection/EnumTranslationCompilerPassTest.php
@@ -1,9 +1,6 @@
 <?php
 namespace Hostnet\Bundle\EntityTranslationBundle\DependencyInjection;
 
-use Hostnet\Bundle\EntityTranslationBundle\MockNoArray\MockNoArray;
-use Hostnet\Bundle\EntityTranslationBundle\MockNoTrans\MockNoTransEnum;
-use Hostnet\Bundle\EntityTranslationBundle\MockXml\MockXmlEnum;
 use Hostnet\Bundle\EntityTranslationBundle\Mock\MockEnum;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
@@ -15,10 +12,12 @@ class EnumTranslationCompilerPassTest extends \PHPUnit_Framework_TestCase
 {
     public function testProcess()
     {
-        $container = new ContainerBuilder();
-        $container->setParameter('kernel.bundles', ["Mock" => MockEnum::class]);
-
+        $resources  = realpath(__DIR__ . "/../Mock/Resources/translations/enum.en.yml");
+        $container  = new ContainerBuilder();
         $translator = new Definition();
+        $translator->setArguments([[], [], [], [
+            'resource_files' => ['en' => [$resources]]
+        ]]);
         $container->setDefinition('translator.default', $translator);
 
         $pass = new EnumTranslationCompilerPass();
@@ -27,47 +26,7 @@ class EnumTranslationCompilerPassTest extends \PHPUnit_Framework_TestCase
         $calls = $translator->getMethodCalls();
 
         $this->assertEquals(1, count($calls));
-        $this->assertEquals(
-            [
-                "addResource",
-                [
-                    "enum",
-                    realpath(__DIR__ . "/../Mock/Resources/translations/enum.en.yml"),
-                    "en",
-                    MockEnum::class
-                ]
-            ],
-            $calls[0]
-        );
-    }
-
-    public function testProcessEntityBundle()
-    {
-        $container = new ContainerBuilder();
-        $container->setParameter('kernel.bundles', ["Mock" => 'Hostnet\Bundle\EntityBundle\HostnetEntityBundle']);
-        $container->setParameter('hostnet.entity.mock.path', realpath(__DIR__ . '/../Mock/'));
-
-        $translator = new Definition();
-        $container->setDefinition('translator.default', $translator);
-
-        $pass = new EnumTranslationCompilerPass();
-        $pass->process($container);
-
-        $calls = $translator->getMethodCalls();
-
-        $this->assertEquals(1, count($calls));
-        $this->assertEquals(
-            [
-                "addResource",
-                [
-                    "enum",
-                    realpath(__DIR__ . "/../Mock/Resources/translations/enum.en.yml"),
-                    "en",
-                    MockEnum::class
-                ]
-            ],
-            $calls[0]
-        );
+        $this->assertEquals(["addResource", ["enum", $resources, "en", MockEnum::class]], $calls[0]);
     }
 
     /**
@@ -75,10 +34,13 @@ class EnumTranslationCompilerPassTest extends \PHPUnit_Framework_TestCase
      */
     public function testProcessNotYml()
     {
-        $container = new ContainerBuilder();
-        $container->setParameter('kernel.bundles', ["MockXml" => MockXmlEnum::class]);
-
+        $resources  = realpath(__DIR__ . "/../MockXml/Resources/translations/enum.en.xml");
+        $container  = new ContainerBuilder();
         $translator = new Definition();
+        $translator->setArguments([[], [], [], [
+            'resource_files' => ['en' => [$resources]]
+        ]]);
+
         $container->setDefinition('translator.default', $translator);
 
         $pass = new EnumTranslationCompilerPass();
@@ -87,10 +49,12 @@ class EnumTranslationCompilerPassTest extends \PHPUnit_Framework_TestCase
 
     public function testProcessNoTrans()
     {
-        $container = new ContainerBuilder();
-        $container->setParameter('kernel.bundles', ["Mock" => MockNoTransEnum::class]);
-
+        $container  = new ContainerBuilder();
         $translator = new Definition();
+        $translator->setArguments([[], [], [], [
+            'resource_files' => ['en' => []]
+        ]]);
+
         $container->setDefinition('translator.default', $translator);
 
         $pass = new EnumTranslationCompilerPass();
@@ -106,10 +70,13 @@ class EnumTranslationCompilerPassTest extends \PHPUnit_Framework_TestCase
      */
     public function testProcessNoArray()
     {
-        $container = new ContainerBuilder();
-        $container->setParameter('kernel.bundles', ["MockNoArray" => MockNoArray::class]);
-
+        $resources  = realpath(__DIR__ . "/../MockNoArray/Resources/translations/enum.en.yml");
+        $container  = new ContainerBuilder();
         $translator = new Definition();
+        $translator->setArguments([[], [], [], [
+            'resource_files' => ['en' => [$resources]]
+        ]]);
+
         $container->setDefinition('translator.default', $translator);
 
         $pass = new EnumTranslationCompilerPass();

--- a/test/Functional/EnumTranslationTest.php
+++ b/test/Functional/EnumTranslationTest.php
@@ -2,9 +2,15 @@
 namespace Hostnet\Bundle\EntityTranslationBundle\Functional;
 
 use Hostnet\Bundle\EntityTranslationBundle\Functional\Fixtures\Enum\PostStatus;
+use Hostnet\Bundle\EntityTranslationBundle\Functional\Fixtures\Enum\ReplyStatus;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\Component\Translation\TranslatorInterface;
 
+/**
+ * Tests if the FooBundle enum translations and app translations can be loaded.
+ *
+ * The Fixtures directory is considered the "app" directory as the kernel resides there.
+ */
 class EnumTranslationTest extends KernelTestCase
 {
     protected function setUp()
@@ -23,7 +29,7 @@ class EnumTranslationTest extends KernelTestCase
         self::assertSame($expected_translation, $translator->trans($key, [], $object_class, $locale));
     }
 
-    public function translationProvider()
+    public static function translationProvider()
     {
         return [
             [PostStatus::class, PostStatus::AWAITING_APPROVAL, 'I am awaiting approval', 'en'],
@@ -34,6 +40,16 @@ class EnumTranslationTest extends KernelTestCase
             [PostStatus::class, PostStatus::VISIBLE, 'Ik ben zichtbaar', 'nl'],
             [PostStatus::class, 'henk', 'henk', 'en'],
             [null, 'henk', 'henk', 'nl'],
+            [ReplyStatus::class, ReplyStatus::CLOSED, 'closed', 'en'],
+            [ReplyStatus::class, ReplyStatus::OPEN, 'open', 'en'],
         ];
+    }
+
+    public function testverifyDefaultAppMessages()
+    {
+        /* @var $translator TranslatorInterface */
+        $translator = static::$kernel->getContainer()->get('translator');
+
+        self::assertSame('correct', $translator->trans('to_verify_the_translations_are_loaded'));
     }
 }

--- a/test/Functional/Fixtures/Enum/ReplyStatus.php
+++ b/test/Functional/Fixtures/Enum/ReplyStatus.php
@@ -1,0 +1,8 @@
+<?php
+namespace Hostnet\Bundle\EntityTranslationBundle\Functional\Fixtures\Enum;
+
+abstract class ReplyStatus
+{
+    const CLOSED = 0;
+    const OPEN = 1;
+}

--- a/test/Functional/Fixtures/Resources/translations/enum.en.yml
+++ b/test/Functional/Fixtures/Resources/translations/enum.en.yml
@@ -1,0 +1,9 @@
+hostnet:
+    bundle:
+        entity_translation_bundle:
+            functional:
+                fixtures:
+                    enum:
+                        reply_status:
+                            open: open
+                            closed: closed

--- a/test/Functional/Fixtures/Resources/translations/messages.en.yml
+++ b/test/Functional/Fixtures/Resources/translations/messages.en.yml
@@ -1,0 +1,1 @@
+to_verify_the_translations_are_loaded: correct

--- a/test/Functional/Fixtures/config/config.yml
+++ b/test/Functional/Fixtures/config/config.yml
@@ -1,3 +1,4 @@
 framework:
     secret: test
     translator: ~
+    test: true


### PR DESCRIPTION
The bundle now uses the previously discovered files by symfony. They were already present as argument for the translator and don't have to be manually discovered. This fixes the issue where `/app/Resources/translations/` was not detected.