### PR TITLE
Skip loading translations for array constants

### DIFF
--- a/src/Loader/EnumLoader.php
+++ b/src/Loader/EnumLoader.php
@@ -44,6 +44,10 @@ class EnumLoader implements LoaderInterface
         foreach ($consts as $const => $value) {
             $key = $this->getPrettyName($domain) . "." . strtolower($const);
 
+            if (is_array($value)) {
+                continue;
+            }
+
             $merged[(string) $value] = $translations->has($key) ? $translations->get($key) : strtolower($const);
         }
 

--- a/src/Loader/EnumLoader.php
+++ b/src/Loader/EnumLoader.php
@@ -42,11 +42,11 @@ class EnumLoader implements LoaderInterface
         // constant value as key and the translation as values, or the constant
         // name if no translation was found.
         foreach ($consts as $const => $value) {
-            $key = $this->getPrettyName($domain) . "." . strtolower($const);
-
             if (is_array($value)) {
                 continue;
             }
+
+            $key = $this->getPrettyName($domain) . "." . strtolower($const);
 
             $merged[(string) $value] = $translations->has($key) ? $translations->get($key) : strtolower($const);
         }

--- a/test/Loader/EnumLoaderTest.php
+++ b/test/Loader/EnumLoaderTest.php
@@ -26,12 +26,6 @@ class EnumLoaderTest extends \PHPUnit_Framework_TestCase
             "en",
             MockEnum::class
         );
-        $this->translator->addResource(
-            "enum",
-            __DIR__ . "/../MockArray/Resources/translations/enum.en.yml",
-            "en",
-            MockArrayEnum::class
-        );
     }
 
     public function testTranslation()
@@ -54,11 +48,17 @@ class EnumLoaderTest extends \PHPUnit_Framework_TestCase
         );
     }
 
-    /**
-     * @requires PHP 5.6
-     */
     public function testTranslationArray()
     {
+        if(defined('HHVM_VERSION'))   $this->markTestSkipped();
+
+        $this->translator->addResource(
+            "enum",
+            __DIR__ . "/../MockArray/Resources/translations/enum.en.yml",
+            "en",
+            MockArrayEnum::class
+        );
+
         $this->assertEquals(
             "Foo1",
             $this->translator->trans(MockArrayEnum::FOO, [], MockArrayEnum::class)

--- a/test/Loader/EnumLoaderTest.php
+++ b/test/Loader/EnumLoaderTest.php
@@ -2,6 +2,7 @@
 namespace Hostnet\Bundle\EntityTranslationBundle\Loader;
 
 use Hostnet\Bundle\EntityTranslationBundle\Mock\MockEnum;
+use Hostnet\Bundle\EntityTranslationBundle\MockArray\MockArrayEnum;
 use Symfony\Component\Translation\Loader\YamlFileLoader;
 use Symfony\Component\Translation\Translator;
 
@@ -25,6 +26,12 @@ class EnumLoaderTest extends \PHPUnit_Framework_TestCase
             "en",
             MockEnum::class
         );
+        $this->translator->addResource(
+            "enum",
+            __DIR__ . "/../MockArray/Resources/translations/enum.en.yml",
+            "en",
+            MockArrayEnum::class
+        );
     }
 
     public function testTranslation()
@@ -44,6 +51,21 @@ class EnumLoaderTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(
             "1",
             $this->translator->trans(MockEnum::FOO)
+        );
+    }
+
+    /**
+     * @requires PHP 5.6
+     */
+    public function testTranslationArray()
+    {
+        $this->assertEquals(
+            "Foo1",
+            $this->translator->trans(MockArrayEnum::FOO, [], MockArrayEnum::class)
+        );
+        $this->assertEquals(
+            "Bar2",
+            $this->translator->trans(MockArrayEnum::BAR, [], MockArrayEnum::class)
         );
     }
 

--- a/test/Mock/MockEnum.php
+++ b/test/Mock/MockEnum.php
@@ -3,7 +3,8 @@ namespace Hostnet\Bundle\EntityTranslationBundle\Mock;
 
 class MockEnum
 {
-    const FOO     = 1;
-    const BAR     = 2;
-    const FOO_BAR = 3;
+    const FOO       = 1;
+    const BAR       = 2;
+    const FOO_BAR   = 3;
+    const FOO_ARRAY = [1, 2, 3];
 }

--- a/test/Mock/MockEnum.php
+++ b/test/Mock/MockEnum.php
@@ -3,8 +3,7 @@ namespace Hostnet\Bundle\EntityTranslationBundle\Mock;
 
 class MockEnum
 {
-    const FOO       = 1;
-    const BAR       = 2;
-    const FOO_BAR   = 3;
-    const FOO_ARRAY = [1, 2, 3];
+    const FOO     = 1;
+    const BAR     = 2;
+    const FOO_BAR = 3;
 }

--- a/test/MockArray/MockArrayEnum.php
+++ b/test/MockArray/MockArrayEnum.php
@@ -1,0 +1,9 @@
+<?php
+namespace Hostnet\Bundle\EntityTranslationBundle\MockArray;
+
+class MockArrayEnum
+{
+    const FOO       = 1;
+    const BAR       = 2;
+    const FOO_ARRAY = [1, 2];
+}

--- a/test/MockArray/Resources/translations/enum.en.yml
+++ b/test/MockArray/Resources/translations/enum.en.yml
@@ -1,0 +1,8 @@
+hostnet:
+    bundle:
+        entity_translation_bundle:
+            mock_array:
+                # Hostnet\Bundle\EntityTranslationBundle\MockArray\MockArrayEnum enum translations
+                mock_array_enum:
+                    foo : "Foo1"
+                    bar : "Bar2"


### PR DESCRIPTION
The translation bundle tries to load the translation for array constants, which results in a ContextErrorException (Array to string conversion). Pull request fixes this by skipping array constants.