### PR TITLE
require doctrine/annotations

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,7 @@
 
     "require": {
         "php"                          : "^7.0|^5.6",
+        "doctrine/annotations"         : "^1.3",
         "symfony/config"               : "^3.0|^2.3",
         "symfony/dependency-injection" : "^3.0|^2.3",
         "symfony/framework-bundle"     : "^3.0|^2.7",


### PR DESCRIPTION
Since symfony 3.2 less packaged are required by symfony. This package is dependent on the doctrine annotation reader. Thus it should require it.