### PR TITLE
Be able to partially override an enum

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,18 +16,19 @@
     "require": {
         "php"                          : "^7.0|^5.6",
         "doctrine/annotations"         : "^1.3",
-        "symfony/config"               : "^3.0|^2.3",
-        "symfony/dependency-injection" : "^3.0|^2.3",
+        "symfony/config"               : "^3.0|^2.7",
+        "symfony/dependency-injection" : "^3.0|^2.7",
         "symfony/framework-bundle"     : "^3.0|^2.7",
-        "symfony/http-kernel"          : "^3.0|^2.3",
-        "symfony/routing"              : "^3.0|^2.3",
+        "symfony/http-kernel"          : "^3.0|^2.7",
+        "symfony/routing"              : "^3.0|^2.7",
         "symfony/translation"          : "^3.0|^2.7",
-        "symfony/yaml"                 : "^3.0|^2.3"
+        "symfony/yaml"                 : "^3.0|^2.7"
     },
 
     "require-dev": {
-        "phpunit/phpunit" : "^5.0|^4.8",
-        "symfony/finder"  : "^3.0|^2.3"
+        "phpunit/phpunit":    "^5.0|^4.8",
+        "hostnet/phpcs-tool": "^4.1.2",
+        "symfony/finder":     "^3.0|^2.7"
     },
 
     "minimum-stability": "stable",

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,0 +1,6 @@
+<?xml version="1.0"?>
+<ruleset name="entity-translation-bundle">
+    <exclude-pattern>test/Functional/Fixtures/cache/</exclude-pattern>
+    <exclude-pattern>test/Functional/Fixtures/TestKernel.php</exclude-pattern>
+    <rule ref="Hostnet" />
+</ruleset>

--- a/src/DependencyInjection/EnumTranslationCompilerPass.php
+++ b/src/DependencyInjection/EnumTranslationCompilerPass.php
@@ -76,7 +76,7 @@ class EnumTranslationCompilerPass implements CompilerPassInterface
 
             // register the found enums into the correct domain and locale
             foreach ($enums as $enum) {
-                $translator->addMethodCall('addResource', ["enum", $file, $locale, $enum]);
+                $translator->addMethodCall('addResource', ['enum', $file, $locale, $enum]);
             }
         }
     }
@@ -104,7 +104,6 @@ class EnumTranslationCompilerPass implements CompilerPassInterface
             foreach ($a as $sub_key => $sub_value) {
                 $b[$key . "." . $sub_key] = $sub_value;
             }
-
         }
         return $b;
     }

--- a/test/DependencyInjection/EnumTranslationCompilerPassTest.php
+++ b/test/DependencyInjection/EnumTranslationCompilerPassTest.php
@@ -6,7 +6,7 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 
 /**
- * @covers Hostnet\Bundle\EntityTranslationBundle\DependencyInjection\EnumTranslationCompilerPass
+ * @covers \Hostnet\Bundle\EntityTranslationBundle\DependencyInjection\EnumTranslationCompilerPass
  */
 class EnumTranslationCompilerPassTest extends \PHPUnit_Framework_TestCase
 {

--- a/test/Functional/EnumTranslationTest.php
+++ b/test/Functional/EnumTranslationTest.php
@@ -38,6 +38,7 @@ class EnumTranslationTest extends KernelTestCase
             [PostStatus::class, PostStatus::DELETED, 'Ik ben verwijderd', 'nl'],
             [PostStatus::class, PostStatus::VISIBLE, 'I am visible', 'en'],
             [PostStatus::class, PostStatus::VISIBLE, 'Ik ben zichtbaar', 'nl'],
+            [PostStatus::class, PostStatus::HIDDEN, 'Hidden (vendor file)', 'en'],
             [PostStatus::class, 'henk', 'henk', 'en'],
             [null, 'henk', 'henk', 'nl'],
             [ReplyStatus::class, ReplyStatus::CLOSED, 'closed', 'en'],

--- a/test/Functional/Fixtures/Enum/PostStatus.php
+++ b/test/Functional/Fixtures/Enum/PostStatus.php
@@ -1,9 +1,17 @@
 <?php
 namespace Hostnet\Bundle\EntityTranslationBundle\Functional\Fixtures\Enum;
 
-abstract class PostStatus
+final class PostStatus
 {
     const AWAITING_APPROVAL = 'awaiting approval';
-    const VISIBLE = 'visible';
-    const DELETED = 'deleted';
+    const VISIBLE           = 'visible';
+    const DELETED           = 'deleted';
+    const HIDDEN            = 'hidden';
+
+    /**
+     * @codeCoverageIgnore private by design because this is an ENUM class
+     */
+    private function __construct()
+    {
+    }
 }

--- a/test/Functional/Fixtures/Enum/ReplyStatus.php
+++ b/test/Functional/Fixtures/Enum/ReplyStatus.php
@@ -1,8 +1,15 @@
 <?php
 namespace Hostnet\Bundle\EntityTranslationBundle\Functional\Fixtures\Enum;
 
-abstract class ReplyStatus
+final class ReplyStatus
 {
     const CLOSED = 0;
-    const OPEN = 1;
+    const OPEN   = 1;
+
+    /**
+     * @codeCoverageIgnore private by design because this is an ENUM class
+     */
+    private function __construct()
+    {
+    }
 }

--- a/test/Functional/Fixtures/Resources/translations/enum.en.yml
+++ b/test/Functional/Fixtures/Resources/translations/enum.en.yml
@@ -7,3 +7,6 @@ hostnet:
                         reply_status:
                             open: open
                             closed: closed
+                        post_status:
+                            hidden: "Hidden (vendor file)"
+                            visibile: "Visible (vendor file, is overridden)"

--- a/test/Functional/Fixtures/config/config.yml
+++ b/test/Functional/Fixtures/config/config.yml
@@ -1,4 +1,4 @@
 framework:
     secret: test
-    translator: ~
+    translator:
     test: true

--- a/test/Loader/EnumLoaderTest.php
+++ b/test/Loader/EnumLoaderTest.php
@@ -7,13 +7,13 @@ use Symfony\Component\Translation\Loader\YamlFileLoader;
 use Symfony\Component\Translation\Translator;
 
 /**
- * @covers Hostnet\Bundle\EntityTranslationBundle\Loader\EnumLoader
+ * @covers \Hostnet\Bundle\EntityTranslationBundle\Loader\EnumLoader
  */
 class EnumLoaderTest extends \PHPUnit_Framework_TestCase
 {
     private $translator;
 
-    public function setUp()
+    protected function setUp()
     {
         $yml_loader = new YamlFileLoader();
         $loader     = new EnumLoader($yml_loader);
@@ -50,7 +50,9 @@ class EnumLoaderTest extends \PHPUnit_Framework_TestCase
 
     public function testTranslationArray()
     {
-        if(defined('HHVM_VERSION'))   $this->markTestSkipped();
+        if (defined('HHVM_VERSION')) {
+            $this->markTestSkipped();
+        }
 
         $this->translator->addResource(
             "enum",


### PR DESCRIPTION
Current behavior:
Partially overriding an enum results in the constant names for all the non-overridden parts.

New behavior:
All the non-overridden parts that had a value before now keep that translation value.

Also the project is now conform Hostnet code style.