### PR TITLE
Fixed compatibility with 3.3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-/test/Functional/Fixtures/cache
-/test/Functional/Fixtures/logs
 /vendor/
 /composer.lock
+/var

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ sudo: false
 
 cache:
   directories:
-    - "$HOME/.composer/cache"
+    - "$HOME/.composer/cache/files"
 
 env:
   - COMPOSER_FLAGS="--prefer-stable"
@@ -19,6 +19,11 @@ matrix:
       env: COMPOSER_FLAGS="--prefer-lowest"
     - php: 7.0
       env: COMPOSER_FLAGS="" SYMFONY_VERSION="3.0.*"
+    - php: 7.1
+      env: COMPOSER_FLAGS="" SYMFONY_VERSION="dev-master"
+  allow_failures:
+    - php: 7.1
+      env: COMPOSER_FLAGS="" SYMFONY_VERSION="dev-master"
 
 before_install: if [[ "$SYMFONY_VERSION" != "" ]]; then composer require --no-update symfony/symfony:${SYMFONY_VERSION}; fi
 

--- a/composer.json
+++ b/composer.json
@@ -37,5 +37,7 @@
             "name":  "Yannick de Lange",
             "email": "ydelange@hostnet.nl"
         }
-    ]
+    ],
+    "minimum-stability" : "dev",
+    "prefer-stable"     : true
 }

--- a/src/DependencyInjection/EnumTranslationCompilerPass.php
+++ b/src/DependencyInjection/EnumTranslationCompilerPass.php
@@ -15,7 +15,21 @@ class EnumTranslationCompilerPass implements CompilerPassInterface
      */
     public function process(ContainerBuilder $container)
     {
-        foreach ($container->getDefinition('translator.default')->getArgument(3)['resource_files'] as $files) {
+        $resource_files = null;
+
+        foreach ($container->getDefinition('translator.default')->getArguments() as $argument) {
+            if (!is_array($argument) || !isset($argument['resource_files'])) {
+                continue;
+            }
+
+            $resource_files = (array) $argument['resource_files'];
+        }
+
+        if (null === $resource_files) {
+            throw new \LogicException('Expected a translator argument to have an array with "resource_files".');
+        }
+
+        foreach ($resource_files as $files) {
             $this->registerEnums($container, array_filter($files, function ($file) {
                 return preg_match('~/enum\.[a-z]+\.[a-z]+$~', $file) === 1;
             }));

--- a/test/Functional/Fixtures/TestKernel.php
+++ b/test/Functional/Fixtures/TestKernel.php
@@ -23,4 +23,14 @@ class TestKernel extends Kernel
     {
         $loader->load(__DIR__.'/config/config.yml');
     }
+
+    public function getCacheDir()
+    {
+        return dirname(__DIR__).'/../../var/cache';
+    }
+
+    public function getLogDir()
+    {
+        return dirname(__DIR__).'/../../var/logs';
+    }
 }

--- a/test/HostnetEntityTranslationBundleTest.php
+++ b/test/HostnetEntityTranslationBundleTest.php
@@ -10,10 +10,6 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
  */
 class HostnetEntityTranslationBundleTest extends \PHPUnit_Framework_TestCase
 {
-    private $expected_services = [
-        'hostnet_entity_translation.enum.loader'
-    ];
-
     public function testBuild()
     {
         $container = new ContainerBuilder();
@@ -21,15 +17,18 @@ class HostnetEntityTranslationBundleTest extends \PHPUnit_Framework_TestCase
         $bundle = new HostnetEntityTranslationBundle();
         $bundle->build($container);
 
-        $definitions = array_keys($container->getDefinitions());
-        $this->assertEquals(count($this->expected_services), count($definitions));
+        $this->assertArrayHasKey('hostnet_entity_translation.enum.loader', $container->getDefinitions());
 
-        foreach ($this->expected_services as $service) {
-            $this->assertContains($service, $definitions);
+        $found = false;
+
+        foreach ($container->getCompilerPassConfig()->getBeforeOptimizationPasses() as $pass) {
+            if (!$pass instanceof EnumTranslationCompilerPass) {
+                continue;
+            }
+
+            $found = true;
         }
 
-        $passes = $container->getCompilerPassConfig()->getBeforeOptimizationPasses();
-        $this->assertEquals(1, count($passes));
-        $this->assertInstanceOf(EnumTranslationCompilerPass::class, $passes[0]);
+        $this->assertTrue($found, 'Expected to find an optimization pass instance of the EnumTranslationCompilerPass');
     }
 }


### PR DESCRIPTION
closes #16 

The argument sequence of the translator has been changed, causing 3.3 to not be able to construct the enum translator loader.